### PR TITLE
Unpack Deno KV entry in SessionManager

### DIFF
--- a/src/session.js
+++ b/src/session.js
@@ -29,7 +29,8 @@ export const SessionManager = (options = {}) => {
           break
 
         case 'denokv':
-          c.session.value = await kv.get(['session', url.hostname, c.session.key])
+          const entry = await kv.get(['session', url.hostname, c.session.key]);
+          c.session.value = entry.value;
           break
 
         default:


### PR DESCRIPTION
As described in #5 the KvEntry returned by kv.get() was not unpacked properly.
This PR simply does the unpacking so the SessionManager can be correctly used with Deno KV.